### PR TITLE
Skip search update when db missing

### DIFF
--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -72,6 +72,10 @@ jobs:
 
       - name: Commit and push changes
         run: |
+          if [ ! -f assets/js/search_db.json ]; then
+            echo "No search_db.json found to commit. Skipping push."
+            exit 0
+          fi
           git config --local user.name 'comphy-search-updater[bot]'
           git config --local user.email "${{ env.APP_BOT_USER_ID }}+comphy-search-updater[bot]@users.noreply.github.com"
           git add assets/js/search_db.json


### PR DESCRIPTION
## Summary
- Avoid attempting a commit/push when the search database was not cloned or copied

## Changes Made
- Guard the update-search workflow to exit early if assets/js/search_db.json is missing

## Testing
- Not run (workflow change only)