### PR TITLE
Batch Dependabot security updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -80,7 +80,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.19.2)
+    json (2.19.5)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3448,9 +3448,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Batch the two open Dependabot security updates into one reviewed PR
- Update the Ruby lockfile for `faraday` and the npm lockfile for transitive `fast-uri`

## Changes
- Bump `faraday` from `2.14.1` to `2.14.2` in `Gemfile.lock`
- Refresh `json` from `2.19.2` to `2.19.5` as part of the Bundler resolution
- Bump transitive `fast-uri` from `3.1.0` to `3.1.2` in `package-lock.json`
- Keep `package.json` and `Gemfile` unchanged; this is a lockfile-only batch

## Testing
- `python3 /Users/comphy-mac/.codex/plugins/cache/codex-vatsal-marketplace/jarvis/1.0.82/skills/gh-dependabot-batch-pr/scripts/run_repo_checks.py --require-scripts`
- `npm run check:node-modules`
- `./scripts/check-phd-thesis-nav-docs.sh`
- `PATH=/opt/homebrew/opt/ruby@3.2/bin:$PATH bundle install`
- `PATH=/opt/homebrew/opt/ruby@3.2/bin:$PATH bundle exec jekyll build`
