### PR TITLE
Align weekly tests Node version

### DIFF
--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22.16.0"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Keep CI node runtime aligned with repository engines and existing site CI.

## Changes
- Update  Node.js version from 20 to 22.16.0 in weekly scheduled test workflow.

## Testing
- Not run (automation rule: no local test execution unless explicitly requested).
